### PR TITLE
6 ft is really 6 units

### DIFF
--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 
     res.add_options()
     ("resolution", po::value<float>(), "The resolution is set to the specified value. Use square grids.\n"
-     "If no resolution options are specified, a 6ft square grid is used")
+     "If no resolution options are specified, a 6 unit square grid is used")
     ("resolution-x", po::value<float>(), "The X side of grid cells is set to the specified value")
     ("resolution-y", po::value<float>(), "The Y side of grid cells is set to the specified value");
 


### PR DESCRIPTION
As far as I can tell this software / code / algorithm is unit independent. If your points are on a metric grid of mm, then everything is mm. If a metric grid of m, then everything is units m. If english yards, then units yards. So the 6 ft comment is really 6 units.
