### PR TITLE
Use std::string instead of char* for args

### DIFF
--- a/include/points2grid/CoreInterp.hpp
+++ b/include/points2grid/CoreInterp.hpp
@@ -56,7 +56,7 @@ public:
 
     virtual int init() = 0;
     virtual int update(double data_x, double data_y, double data_z) = 0;
-    virtual int finish(char *outputName, int outputFormat, unsigned int outputType) = 0;
+    virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType) = 0;
 
 protected:
     double GRID_DIST_X;

--- a/include/points2grid/InCoreInterp.hpp
+++ b/include/points2grid/InCoreInterp.hpp
@@ -67,8 +67,8 @@ public:
 
     virtual int init();
     virtual int update(double data_x, double data_y, double data_z);
-    virtual int finish(char *outputName, int outputFormat, unsigned int outputType);
-    virtual int finish(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
+    virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
 
 private:
     GridPoint **interp;
@@ -82,6 +82,6 @@ private:
 
     void updateGridPoint(int x, int y, double data_z, double distance);
     void printArray();
-    int outputFile(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    int outputFile(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
 };
 

--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -67,8 +67,8 @@ public:
                   int _window_size, int _interpolation_mode);
     ~Interpolation();
 
-    int init(char *inputName, int inputFormat);
-    int interpolation(char *inputName, char *outputName, int inputFormat,
+    int init(const std::string& inputName, int inputFormat);
+    int interpolation(const std::string& inputName, const std::string& outputName, int inputFormat,
                       int outputFormat, unsigned int type);
     unsigned int getDataCount();
 

--- a/include/points2grid/OutCoreInterp.hpp
+++ b/include/points2grid/OutCoreInterp.hpp
@@ -76,8 +76,8 @@ public:
 
     virtual int init();
     virtual int update(double data_x, double data_y, double data_z);
-    virtual int finish(char *outputName, int outputFormat, unsigned int outputType);
-    virtual int finish(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
+    virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
 
 private:
     void updateInterpArray(int fileNum, double data_x, double data_y, double data_z);
@@ -89,7 +89,7 @@ private:
     void updateGridPoint(int fileNum, int x, int y, double data_z, double distance);
     int findFileNum(double data_y);
     void finalize();
-    int outputFile(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    int outputFile(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
     void get_temp_file_name(char *fname, size_t fname_len);
 
 public:

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -172,12 +172,12 @@ int InCoreInterp::update(double data_x, double data_y, double data_z)
     return 0;
 }
 
-int InCoreInterp::finish(char *outputName, int outputFormat, unsigned int outputType)
+int InCoreInterp::finish(const std::string& outputName, int outputFormat, unsigned int outputType)
 {
   return finish(outputName, outputFormat, outputType, 0, 0);
 }
 
-int InCoreInterp::finish(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
+int InCoreInterp::finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
 {
     int rc;
     int i,j;
@@ -458,7 +458,7 @@ void InCoreInterp::printArray()
     cerr << endl;
 }
 
-int InCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
+int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
 {
     int i,j,k;
 
@@ -487,7 +487,7 @@ int InCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int ou
         {
             if(outputType & type[i])
             {
-                strncpy(arcFileName, outputName, sizeof(arcFileName));
+                strncpy(arcFileName, outputName.c_str(), sizeof(arcFileName));
                 strncat(arcFileName, ext[i], strlen(ext[i]));
                 strncat(arcFileName, ".asc", strlen(".asc"));
 
@@ -517,7 +517,7 @@ int InCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int ou
         {
             if(outputType & type[i])
             {
-                strncpy(gridFileName, outputName, sizeof(arcFileName));
+                strncpy(gridFileName, outputName.c_str(), sizeof(arcFileName));
                 strncat(gridFileName, ext[i], strlen(ext[i]));
                 strncat(gridFileName, ".grid", strlen(".grid"));
 
@@ -732,7 +732,7 @@ int InCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int ou
         {
             if(outputType & type[i])
             {
-                strncpy(gdalFileName, outputName, sizeof(gdalFileName));
+                strncpy(gdalFileName, outputName.c_str(), sizeof(gdalFileName));
                 strncat(gdalFileName, ext[i], strlen(ext[i]));
                 strncat(gdalFileName, ".tif", strlen(".tif"));
 

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -89,7 +89,7 @@ Interpolation::~Interpolation()
     delete interp;
 }
 
-int Interpolation::init(char *inputName, int inputFormat)
+int Interpolation::init(const std::string& inputName, int inputFormat)
 {
     //unsigned int i;
 
@@ -108,13 +108,7 @@ int Interpolation::init(char *inputName, int inputFormat)
     //t0 = times(&tbuf);
     t0 = clock();
 
-    if(inputName == NULL)
-    {
-        cerr << "Wrong Input File Name" << endl;
-        return -1;
-    }
-
-    printf("inputName: '%s'\n", inputName);
+    printf("inputName: '%s'\n", inputName.c_str());
 
     if (inputFormat == INPUT_ASCII) {
         FILE *fp;
@@ -122,7 +116,7 @@ int Interpolation::init(char *inputName, int inputFormat)
         double data_x, data_y;
         //double data_z;
 
-        if((fp = fopen(inputName, "r")) == NULL)
+        if((fp = fopen(inputName.c_str(), "r")) == NULL)
         {
             cerr << "file open error" << endl;
             return -1;
@@ -263,8 +257,8 @@ int Interpolation::init(char *inputName, int inputFormat)
     return 0;
 }
 
-int Interpolation::interpolation(char *inputName,
-                                 char *outputName,
+int Interpolation::interpolation(const std::string& inputName,
+                                 const std::string& outputName,
                                  int inputFormat,
                                  int outputFormat,
                                  unsigned int outputType)
@@ -295,7 +289,7 @@ int Interpolation::interpolation(char *inputName,
         FILE *fp;
         char line[1024];
 
-        if((fp = fopen(inputName, "r")) == NULL)
+        if((fp = fopen(inputName.c_str(), "r")) == NULL)
         {
             printf("file open error\n");
             return -1;

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -263,12 +263,12 @@ int OutCoreInterp::update(double data_x, double data_y, double data_z)
     return 0;
 }
 
-int OutCoreInterp::finish(char *outputName, int outputFormat, unsigned int outputType)
+int OutCoreInterp::finish(const std::string& outputName, int outputFormat, unsigned int outputType)
 {
     return finish(outputName, outputFormat, outputType, 0, 0);
 }
 
-int OutCoreInterp::finish(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
+int OutCoreInterp::finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
 {
     int i, j;
     GridPoint *p;
@@ -723,7 +723,7 @@ void OutCoreInterp::updateGridPoint(int fileNum, int x, int y, double data_z, do
     }
 }
 
-int OutCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
+int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
 {
     int i, j, k, l, t;
 
@@ -751,7 +751,7 @@ int OutCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int o
         {
             if(outputType & type[i])
             {
-                strncpy(arcFileName, outputName, sizeof(arcFileName));
+                strncpy(arcFileName, outputName.c_str(), sizeof(arcFileName));
                 strncat(arcFileName, ext[i], strlen(ext[i]));
                 strncat(arcFileName, ".asc", strlen(".asc"));
 
@@ -781,7 +781,7 @@ int OutCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int o
         {
             if(outputType & type[i])
             {
-                strncpy(gridFileName, outputName, sizeof(arcFileName));
+                strncpy(gridFileName, outputName.c_str(), sizeof(arcFileName));
                 strncat(gridFileName, ext[i], strlen(ext[i]));
                 strncat(gridFileName, ".grid", strlen(".grid"));
 
@@ -1018,7 +1018,7 @@ int OutCoreInterp::outputFile(char *outputName, int outputFormat, unsigned int o
         {
             if(outputType & type[i])
             {
-                strncpy(gdalFileName, outputName, sizeof(gdalFileName));
+                strncpy(gdalFileName, outputName.c_str(), sizeof(gdalFileName));
                 strncat(gdalFileName, ext[i], strlen(ext[i]));
                 strncat(gdalFileName, ".tif", strlen(".tif"));
 


### PR DESCRIPTION
This *should* not break most downstream calls a la [PDAL](https://github.com/PDAL/PDAL/blob/master/plugins/p2g/io/P2gWriter.cpp#L208), since std::string has a `char *` constructor.

I made these changes to make the [testing](https://github.com/gadomski/points2grid/tree/testing) a bit easier.