### PR TITLE
Enable travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+
+compiler:
+    - clang
+    - gcc
+
+install:
+    - sudo apt-get install libboost-all-dev
+
+script:
+    - scripts/build_and_test.sh

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,0 +1,5 @@
+mkdir build && cd build
+cmake .. -DWITH_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && \
+    make && \
+    test/points2grid-test && \
+    sudo make install

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ configure_file(
 include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/test
-    ${gtest_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/vendor/gtest-1.7.0/include
     )
 
 set(src


### PR DESCRIPTION
For now, we don't build with GDAL support, since none of the unit tests exercise the GDAL functions.

We test w/ gcc and clang.