### PR TITLE
Fix boundary definition bug in ArcGIS and Grid headers

### DIFF
--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -543,8 +543,8 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
             {
                 fprintf(arcFiles[i], "ncols %d\n", GRID_SIZE_X);
                 fprintf(arcFiles[i], "nrows %d\n", GRID_SIZE_Y);
-                fprintf(arcFiles[i], "xllcorner %f\n", min_x);
-                fprintf(arcFiles[i], "yllcorner %f\n", min_y);
+                fprintf(arcFiles[i], "xllcorner %f\n", min_x - 0.5*GRID_DIST_X);
+                fprintf(arcFiles[i], "yllcorner %f\n", min_y - 0.5*GRID_DIST_Y);
                 fprintf(arcFiles[i], "cellsize %f\n", GRID_DIST_X);
                 fprintf(arcFiles[i], "NODATA_value -9999\n");
             }
@@ -558,10 +558,10 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
         {
             if(gridFiles[i] != NULL)
             {
-                fprintf(gridFiles[i], "north: %f\n", max_y);
-                fprintf(gridFiles[i], "south: %f\n", min_y);
-                fprintf(gridFiles[i], "east: %f\n", max_x);
-                fprintf(gridFiles[i], "west: %f\n", min_x);
+                fprintf(gridFiles[i], "north: %f\n", min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y);
+                fprintf(gridFiles[i], "south: %f\n", min_y - 0.5*GRID_DIST_Y);
+                fprintf(gridFiles[i], "east: %f\n", min_x - 0.5*GRID_DIST_X + GRID_DIST_X*GRID_SIZE_X);
+                fprintf(gridFiles[i], "west: %f\n", min_x - 0.5*GRID_DIST_X);
                 fprintf(gridFiles[i], "rows: %d\n", GRID_SIZE_Y);
                 fprintf(gridFiles[i], "cols: %d\n", GRID_SIZE_X);
             }

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -807,8 +807,8 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
             {
                 fprintf(arcFiles[i], "ncols %d\n", GRID_SIZE_X);
                 fprintf(arcFiles[i], "nrows %d\n", GRID_SIZE_Y);
-                fprintf(arcFiles[i], "xllcorner %f\n", min_x);
-                fprintf(arcFiles[i], "yllcorner %f\n", min_y);
+                fprintf(arcFiles[i], "xllcorner %f\n", min_x - 0.5*GRID_DIST_X);
+                fprintf(arcFiles[i], "yllcorner %f\n", min_y - 0.5*GRID_DIST_Y);
                 fprintf(arcFiles[i], "cellsize %f\n", GRID_DIST_X);
                 fprintf(arcFiles[i], "NODATA_value -9999\n");
             }
@@ -822,10 +822,10 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
         {
             if(gridFiles[i] != NULL)
             {
-                fprintf(gridFiles[i], "north: %f\n", max_y);
-                fprintf(gridFiles[i], "south: %f\n", min_y);
-                fprintf(gridFiles[i], "east: %f\n", max_x);
-                fprintf(gridFiles[i], "west: %f\n", min_x);
+                fprintf(gridFiles[i], "north: %f\n", min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y);
+                fprintf(gridFiles[i], "south: %f\n", min_y - 0.5*GRID_DIST_Y);
+                fprintf(gridFiles[i], "east: %f\n", min_x - 0.5*GRID_DIST_X + GRID_DIST_X*GRID_SIZE_X);
+                fprintf(gridFiles[i], "west: %f\n", min_x - 0.5*GRID_DIST_X);
                 fprintf(gridFiles[i], "rows: %d\n", GRID_SIZE_Y);
                 fprintf(gridFiles[i], "cols: %d\n", GRID_SIZE_X);
             }

--- a/test/interpolation_test.cpp
+++ b/test/interpolation_test.cpp
@@ -10,6 +10,73 @@ namespace points2grid
 {
 
 
+namespace
+{
+
+
+struct AscHeader
+{
+    int ncols;
+    int nrows;
+    double xllcorner;
+    double yllcorner;
+    double cellsize;
+    int NODATA_value;
+};
+
+struct GridHeader
+{
+    double north;
+    double south;
+    double east;
+    double west;
+    int rows;
+    int cols;
+};
+
+
+AscHeader read_asc_header(std::istream& is)
+{
+    AscHeader header;
+    std::streamsize n = std::numeric_limits<std::streamsize>::max();
+    is.ignore(n, ' ');
+    is >> header.ncols;
+    is.ignore(n, ' ');
+    is >> header.nrows;
+    is.ignore(n, ' ');
+    is >> header.xllcorner;
+    is.ignore(n, ' ');
+    is >> header.yllcorner;
+    is.ignore(n, ' ');
+    is >> header.cellsize;
+    is.ignore(n, ' ');
+    is >> header.NODATA_value;
+    return header;
+}
+
+GridHeader read_grid_header(std::istream& is)
+{
+    GridHeader header;
+    std::streamsize n = std::numeric_limits<std::streamsize>::max();
+    is.ignore(n, ' ');
+    is >> header.north;
+    is.ignore(n, ' ');
+    is >> header.south;
+    is.ignore(n, ' ');
+    is >> header.east;
+    is.ignore(n, ' ');
+    is >> header.west;
+    is.ignore(n, ' ');
+    is >> header.rows;
+    is.ignore(n, ' ');
+    is >> header.cols;
+    return header;
+}
+
+
+}
+
+
 class InterpolationTest : public ::testing::Test
 {
 public:
@@ -28,6 +95,18 @@ public:
         std::remove((outfile + ".mean.asc").c_str());
         std::remove((outfile + ".min.asc").c_str());
         std::remove((outfile + ".std.asc").c_str());
+        std::remove((outfile + ".den.grid").c_str());
+        std::remove((outfile + ".idw.grid").c_str());
+        std::remove((outfile + ".max.grid").c_str());
+        std::remove((outfile + ".mean.grid").c_str());
+        std::remove((outfile + ".min.grid").c_str());
+        std::remove((outfile + ".std.grid").c_str());
+        std::remove((outfile + ".den.tif").c_str());
+        std::remove((outfile + ".idw.tif").c_str());
+        std::remove((outfile + ".max.tif").c_str());
+        std::remove((outfile + ".mean.tif").c_str());
+        std::remove((outfile + ".min.tif").c_str());
+        std::remove((outfile + ".std.tif").c_str());
     }
 
     std::string infile;
@@ -59,6 +138,34 @@ TEST_F(InterpolationTest, Interpolate)
     EXPECT_EQ(4, interp.getDataCount());
     EXPECT_EQ(2, interp.getGridSizeX());
     EXPECT_EQ(2, interp.getGridSizeY());
+}
+
+
+TEST_F(InterpolationTest, Headers)
+{
+    Interpolation interp(1, 1, 1, 3, INTERP_INCORE);
+    interp.init(infile, INPUT_ASCII);
+    interp.interpolation(infile, outfile, INPUT_ASCII, OUTPUT_FORMAT_ALL, OUTPUT_TYPE_ALL);
+
+    std::ifstream asc;
+    asc.open((outfile + ".idw.asc").c_str());
+    AscHeader asc_header = read_asc_header(asc);
+    EXPECT_EQ(asc_header.ncols, 2);
+    EXPECT_EQ(asc_header.nrows, 2);
+    EXPECT_DOUBLE_EQ(asc_header.xllcorner, 0.5);
+    EXPECT_DOUBLE_EQ(asc_header.yllcorner, 0.5);
+    EXPECT_DOUBLE_EQ(asc_header.cellsize, 1.0);
+    EXPECT_EQ(asc_header.NODATA_value, -9999);
+
+    std::ifstream grid;
+    grid.open((outfile + ".idw.grid").c_str());
+    GridHeader grid_header = read_grid_header(grid);
+    EXPECT_DOUBLE_EQ(grid_header.north, 2.5);
+    EXPECT_DOUBLE_EQ(grid_header.south, 0.5);
+    EXPECT_DOUBLE_EQ(grid_header.east, 2.5);
+    EXPECT_DOUBLE_EQ(grid_header.west, 0.5);
+    EXPECT_EQ(grid_header.rows, 2);
+    EXPECT_EQ(grid_header.cols, 2);
 }
 
 


### PR DESCRIPTION
The point (min_x, min_y) is the southwest corner of the bounding box of the input dataset as well as the center of the bottom left cell in the grid, and the point (max_x, max_y) is the northeast corner of the bounding box of the input dataset.

The [ArcGIS format](http://resources.arcgis.com/en/help/main/10.1/index.html#/Esri_ASCII_raster_format/009t0000000z000000/) allows the coordinates of the origin to be defined by either the center or lower left corner of the lower left cell. I've fixed the values printed to be consistent with the lower left corner.

The [GRASS Grid format](http://grass.osgeo.org/grass71/manuals/r.in.ascii.html) calls for the N, S, E, W boundaries to describe the outer edges of the region. Printed values now represent these edges instead of the bounding box of the input dataset.

Related to bugs #6 and #7  