### PR TITLE
Fix GeoTiff Grid Transformation

### DIFF
--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -379,10 +379,11 @@ int main(int argc, char **argv)
     Interpolation *ip = new Interpolation(GRID_DIST_X, GRID_DIST_Y, searchRadius,
                                           window_size, interpolation_mode);
 
+
     if(ip->init(inputName, input_format) < 0)
     {
-        fprintf(stderr, "Interpolation::init() error\n");
-        return -1;
+	fprintf(stderr, "Interpolation::init() error\n");
+	return -1;
     }
 
     t1 = clock();

--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -92,11 +92,16 @@ int main(int argc, char **argv)
     double searchRadius = (double) sqrt(2.0) * GRID_DIST_X;
     int window_size = 0;
 
+    bool user_defined_bounds = false;
+    double n = 0.0, s = 0.0, e = 0.0, w = 0.0;
+//    std::vector<double> bounds;
+
     // argument processing..
     po::options_description general("General options"),
        df("Data file"),
        ot("Output Type"),
        res("Resolution"),
+       bnds("Grid Bounds (optional, all four must be included if used)"),
        nf("Null Filling"),
        desc;
 
@@ -139,11 +144,17 @@ int main(int argc, char **argv)
     ("resolution-x", po::value<float>(), "The X side of grid cells is set to the specified value")
     ("resolution-y", po::value<float>(), "The Y side of grid cells is set to the specified value");
 
+    bnds.add_options()
+    ("north,n", po::value<double>(), "The northern edge of the grid")
+    ("south,s", po::value<double>(), "The southern edge of the grid")
+    ("east,e", po::value<double>(), "The eastern edge of the grid")
+    ("west,w", po::value<double>(), "The western edge of the grid");
+
     nf.add_options()
     ("fill", "fills nulls in the DEM. Default window size is 3.")
     ("fill_window_size", po::value<int>(), "The fill window is set to value. Permissible values are 3, 5 and 7.");
 
-    desc.add(general).add(df).add(ot).add(res).add(nf);
+    desc.add(general).add(df).add(ot).add(res).add(bnds).add(nf);
 
     po::variables_map vm;
 
@@ -205,6 +216,26 @@ int main(int argc, char **argv)
             }
         }
 
+        int bounds_count = vm.count("north") + vm.count("south") + vm.count("east") + vm.count("west");
+        if (bounds_count > 0) {
+            if (bounds_count != 4) {
+                throw std::logic_error("To use bounds you must enter all for values (n, s, e, w)");
+            }
+            user_defined_bounds = true;
+            n = vm["north"].as<double>();
+            s = vm["south"].as<double>();
+            e = vm["east"].as<double>();
+            w = vm["west"].as<double>();
+        }
+
+//        if(vm.count("bounds")) {
+//            bounds = vm["bounds"].as<std::vector<double> >();
+//            if (bounds.size() != 4) {
+//                throw std::logic_error("four values (n, s, e, w) must be entered for bounds");
+//            }
+//            user_defined_bounds = true;
+//        }
+
         if(vm.count("min")) {
             type |= OUTPUT_TYPE_MIN;
         }
@@ -221,7 +252,7 @@ int main(int argc, char **argv)
             type |= OUTPUT_TYPE_IDW;
         }
 
-	if(vm.count("std")) {
+        if(vm.count("std")) {
             type |= OUTPUT_TYPE_STD;
         }
 
@@ -380,10 +411,11 @@ int main(int argc, char **argv)
                                           window_size, interpolation_mode);
 
 
-    if(ip->init(inputName, input_format) < 0)
+    int init_result = user_defined_bounds ? ip->init(inputName, n, s, e, w) : ip->init(inputName, input_format);
+    if(init_result < 0)
     {
-	fprintf(stderr, "Interpolation::init() error\n");
-	return -1;
+        fprintf(stderr, "Interpolation::init() error\n");
+        return -1;
     }
 
     t1 = clock();

--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -64,10 +64,11 @@ class P2G_DLL Interpolation
 {
 public:
     Interpolation(double x_dist, double y_dist, double radius,
-                  int _window_size, int _interpolation_mode);
+		  int _window_size, int _interpolation_mode);
     ~Interpolation();
 
     int init(const std::string& inputName, int inputFormat);
+    int init(const std::string& inputName, int inputFormat, double n, double s, double e, double w);
     int interpolation(const std::string& inputName, const std::string& outputName, int inputFormat,
                       int outputFormat, unsigned int type);
     unsigned int getDataCount();

--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -68,7 +68,7 @@ public:
     ~Interpolation();
 
     int init(const std::string& inputName, int inputFormat);
-    int init(const std::string& inputName, int inputFormat, double n, double s, double e, double w);
+    int init(const std::string& inputName, double n, double s, double e, double w);
     int interpolation(const std::string& inputName, const std::string& outputName, int inputFormat,
                       int outputFormat, unsigned int type);
     unsigned int getDataCount();

--- a/include/points2grid/OutCoreInterp.hpp
+++ b/include/points2grid/OutCoreInterp.hpp
@@ -78,6 +78,7 @@ public:
     virtual int update(double data_x, double data_y, double data_z);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    void isUserDefinedGrid(bool defined);
 
 private:
     void updateInterpArray(int fileNum, double data_x, double data_y, double data_z);
@@ -106,6 +107,8 @@ private:
     list<UpdateInfo> *qlist;
     GridMap **gridMap;
     int openFile;
+
+    bool user_defined_grid;
 };
 
 class UpdateInfo

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -543,8 +543,8 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
             {
                 fprintf(arcFiles[i], "ncols %d\n", GRID_SIZE_X);
                 fprintf(arcFiles[i], "nrows %d\n", GRID_SIZE_Y);
-                fprintf(arcFiles[i], "xllcorner %f\n", min_x);
-                fprintf(arcFiles[i], "yllcorner %f\n", min_y);
+                fprintf(arcFiles[i], "xllcorner %f\n", min_x - 0.5*GRID_DIST_X);
+                fprintf(arcFiles[i], "yllcorner %f\n", min_y - 0.5*GRID_DIST_Y);
                 fprintf(arcFiles[i], "cellsize %f\n", GRID_DIST_X);
                 fprintf(arcFiles[i], "NODATA_value -9999\n");
             }
@@ -558,10 +558,10 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
         {
             if(gridFiles[i] != NULL)
             {
-                fprintf(gridFiles[i], "north: %f\n", max_y);
-                fprintf(gridFiles[i], "south: %f\n", min_y);
-                fprintf(gridFiles[i], "east: %f\n", max_x);
-                fprintf(gridFiles[i], "west: %f\n", min_x);
+                fprintf(gridFiles[i], "north: %f\n", min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y);
+                fprintf(gridFiles[i], "south: %f\n", min_y - 0.5*GRID_DIST_Y);
+                fprintf(gridFiles[i], "east: %f\n", min_x - 0.5*GRID_DIST_X + GRID_DIST_X*GRID_SIZE_X);
+                fprintf(gridFiles[i], "west: %f\n", min_x - 0.5*GRID_DIST_X);
                 fprintf(gridFiles[i], "rows: %d\n", GRID_SIZE_Y);
                 fprintf(gridFiles[i], "cols: %d\n", GRID_SIZE_X);
             }

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -753,7 +753,19 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
                             return -1;
                         } else {
                             if (adfGeoTransform)
+                            {
                                 gdalFiles[i]->SetGeoTransform(adfGeoTransform);
+                            }
+                            else
+                            {
+                                double defaultTransform [6] = { min_x - 0.5*GRID_DIST_X,                            // top left x
+                                                                (double)GRID_DIST_X,                                // w-e pixel resolution
+                                                                0.0,                                                // no rotation/shear
+                                                                min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y,  // top left y
+                                                                0.0,                                                // no rotation/shear
+                                                                -(double)GRID_DIST_Y };                             // n-x pixel resolution (negative value)
+                                gdalFiles[i]->SetGeoTransform(defaultTransform);
+                            }
                             if (wkt)
                                 gdalFiles[i]->SetProjection(wkt);
                         }

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -413,6 +413,9 @@ void InCoreInterp::update_fourth_quadrant(double data_z, int base_x, int base_y,
 
 void InCoreInterp::updateGridPoint(int x, int y, double data_z, double distance)
 {
+    // Add checks for invalid indices that result from user-defined grids
+    if (x >= GRID_SIZE_X || x < 0 || y >= GRID_SIZE_Y || y < 0) return;
+
     if(interp[x][y].Zmin > data_z)
         interp[x][y].Zmin = data_z;
     if(interp[x][y].Zmax < data_z)

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -296,12 +296,14 @@ int Interpolation::init(const std::string& inputName, double n, double s, double
     if (interpolation_mode == INTERP_OUTCORE) {
         cerr << "Using out of core interp code" << endl;;
 
-        interp = new OutCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
-        if(interp == NULL)
+        OutCoreInterp *ointerp = new OutCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
+        if(ointerp == NULL)
         {
             cerr << "OutCoreInterp construction error" << endl;
             return -1;
         }
+        ointerp->isUserDefinedGrid(true);
+        interp = ointerp;
 
         cerr << "Interpolation uses out-of-core algorithm" << endl;
 

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -257,6 +257,73 @@ int Interpolation::init(const std::string& inputName, int inputFormat)
     return 0;
 }
 
+int Interpolation::init(const std::string& inputName, int inputFormat, double n, double s, double e, double w)
+{
+    printf("inputName: '%s'\n", inputName.c_str());
+    printf("Grid Bounds:\nNorth: %f\nSouth: %f\nEast: %f\nWest: %f\n", n, s, e, w);
+
+    // Check that the bounding box is properly defined
+    if (n-s > GRID_DIST_Y && e-w > GRID_DIST_X)
+    {
+	// The user defines the edges of the bounding box, here we want the min/max values
+	// to represent the centers of the edge cells
+	min_x = w + GRID_DIST_X/2.0;
+	min_y = s + GRID_DIST_Y/2.0;
+	max_x = e - GRID_DIST_X/2.0;
+	max_y = n - GRID_DIST_Y/2.0;
+
+    } else {
+	cerr << "Error in bounding box definition" << endl;
+	return -1;
+    }
+
+    GRID_SIZE_X = (int)(ceil((max_x - min_x)/GRID_DIST_X)) + 1;
+    GRID_SIZE_Y = (int)(ceil((max_y - min_y)/GRID_DIST_Y)) + 1;
+
+    cerr << "GRID_SIZE_X " << GRID_SIZE_X << endl;
+    cerr << "GRID_SIZE_Y " << GRID_SIZE_Y << endl;
+
+    if (interpolation_mode == INTERP_AUTO) {
+	// if the size is too big to fit in memory,
+	// then construct out-of-core structure
+	if(GRID_SIZE_X * GRID_SIZE_Y > MEM_LIMIT) {
+	    interpolation_mode= INTERP_OUTCORE;
+	} else {
+	    interpolation_mode = INTERP_INCORE;
+	}
+    }
+
+    if (interpolation_mode == INTERP_OUTCORE) {
+	cerr << "Using out of core interp code" << endl;;
+
+	interp = new OutCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
+	if(interp == NULL)
+	{
+	    cerr << "OutCoreInterp construction error" << endl;
+	    return -1;
+	}
+
+	cerr << "Interpolation uses out-of-core algorithm" << endl;
+
+    } else {
+	cerr << "Using incore interp code" << endl;
+
+	interp = new InCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
+
+	cerr << "Interpolation uses in-core algorithm" << endl;
+    }
+
+    if(interp->init() < 0)
+    {
+	cerr << "inter->init() error" << endl;
+	return -1;
+    }
+
+    cerr << "Interpolation::init() done successfully" << endl;
+
+    return 0;
+}
+
 int Interpolation::interpolation(const std::string& inputName,
                                  const std::string& outputName,
                                  int inputFormat,

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -257,24 +257,24 @@ int Interpolation::init(const std::string& inputName, int inputFormat)
     return 0;
 }
 
-int Interpolation::init(const std::string& inputName, int inputFormat, double n, double s, double e, double w)
+int Interpolation::init(const std::string& inputName, double n, double s, double e, double w)
 {
     printf("inputName: '%s'\n", inputName.c_str());
     printf("Grid Bounds:\nNorth: %f\nSouth: %f\nEast: %f\nWest: %f\n", n, s, e, w);
 
     // Check that the bounding box is properly defined
-    if (n-s > GRID_DIST_Y && e-w > GRID_DIST_X)
+    if (n-s >= GRID_DIST_Y && e-w >= GRID_DIST_X)
     {
-	// The user defines the edges of the bounding box, here we want the min/max values
-	// to represent the centers of the edge cells
-	min_x = w + GRID_DIST_X/2.0;
-	min_y = s + GRID_DIST_Y/2.0;
-	max_x = e - GRID_DIST_X/2.0;
-	max_y = n - GRID_DIST_Y/2.0;
+        // The user defines the edges of the bounding box, here we want the min/max values
+        // to represent the centers of the edge cells
+        min_x = w + GRID_DIST_X/2.0;
+        min_y = s + GRID_DIST_Y/2.0;
+        max_x = e - GRID_DIST_X/2.0;
+        max_y = n - GRID_DIST_Y/2.0;
 
     } else {
-	cerr << "Error in bounding box definition" << endl;
-	return -1;
+        cerr << "Error in bounding box definition" << endl;
+        return -1;
     }
 
     GRID_SIZE_X = (int)(ceil((max_x - min_x)/GRID_DIST_X)) + 1;
@@ -284,39 +284,39 @@ int Interpolation::init(const std::string& inputName, int inputFormat, double n,
     cerr << "GRID_SIZE_Y " << GRID_SIZE_Y << endl;
 
     if (interpolation_mode == INTERP_AUTO) {
-	// if the size is too big to fit in memory,
-	// then construct out-of-core structure
-	if(GRID_SIZE_X * GRID_SIZE_Y > MEM_LIMIT) {
-	    interpolation_mode= INTERP_OUTCORE;
-	} else {
-	    interpolation_mode = INTERP_INCORE;
-	}
+        // if the size is too big to fit in memory,
+        // then construct out-of-core structure
+        if(GRID_SIZE_X * GRID_SIZE_Y > MEM_LIMIT) {
+            interpolation_mode= INTERP_OUTCORE;
+        } else {
+            interpolation_mode = INTERP_INCORE;
+        }
     }
 
     if (interpolation_mode == INTERP_OUTCORE) {
-	cerr << "Using out of core interp code" << endl;;
+        cerr << "Using out of core interp code" << endl;;
 
-	interp = new OutCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
-	if(interp == NULL)
-	{
-	    cerr << "OutCoreInterp construction error" << endl;
-	    return -1;
-	}
+        interp = new OutCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
+        if(interp == NULL)
+        {
+            cerr << "OutCoreInterp construction error" << endl;
+            return -1;
+        }
 
-	cerr << "Interpolation uses out-of-core algorithm" << endl;
+        cerr << "Interpolation uses out-of-core algorithm" << endl;
 
     } else {
-	cerr << "Using incore interp code" << endl;
+        cerr << "Using incore interp code" << endl;
 
-	interp = new InCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
+        interp = new InCoreInterp(GRID_DIST_X, GRID_DIST_Y, GRID_SIZE_X, GRID_SIZE_Y, radius_sqr, min_x, max_x, min_y, max_y, window_size);
 
-	cerr << "Interpolation uses in-core algorithm" << endl;
+        cerr << "Interpolation uses in-core algorithm" << endl;
     }
 
     if(interp->init() < 0)
     {
-	cerr << "inter->init() error" << endl;
-	return -1;
+        cerr << "inter->init() error" << endl;
+        return -1;
     }
 
     cerr << "Interpolation::init() done successfully" << endl;

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -1039,7 +1039,19 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
                             return -1;
                         } else {
                             if (adfGeoTransform)
+                            {
                                 gdalFiles[i]->SetGeoTransform(adfGeoTransform);
+                            }
+                            else
+                            {
+                                double defaultTransform [6] = { min_x - 0.5*GRID_DIST_X,                            // top left x
+                                                                (double)GRID_DIST_X,                                // w-e pixel resolution
+                                                                0.0,                                                // no rotation/shear
+                                                                min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y,  // top left y
+                                                                0.0,                                                // no rotation/shear
+                                                                -(double)GRID_DIST_Y };                             // n-x pixel resolution (negative value)
+                                gdalFiles[i]->SetGeoTransform(defaultTransform);
+                            }
                             if (wkt)
                                 gdalFiles[i]->SetProjection(wkt);
                         }

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -163,6 +163,8 @@ OutCoreInterp::OutCoreInterp(double dist_x, double dist_y,
 
     openFile = -1;
 
+    user_defined_grid = false;
+
     //cout << overlapSize << endl;
     //cout << "data size: " << (size_x * size_y) << " numFiles: " << numFiles << " local_grid_size_y: " << local_grid_size_y << " overlap: " << overlapSize << endl;
     //cout << fname << endl;
@@ -217,12 +219,16 @@ int OutCoreInterp::update(double data_x, double data_y, double data_z)
     int fileNum;
 
     //fileNum = upper_grid_y / local_grid_size_y;
-    if((fileNum = findFileNum(data_y)) < 0)
+    fileNum = findFileNum(data_y);
+    if(fileNum < 0 || fileNum > numFiles-1)
     {
+        if (user_defined_grid) return 0;
         cerr << "OutCoreInterp::update() findFileNum() error!" << endl;
         cerr << "data_x: " << data_x << " data_y: " << data_y << " grid_y: " << (int)(data_y/GRID_DIST_Y) << " fileNum: " << fileNum << " open file: " << openFile << endl;
         return -1;
     }
+
+//    cout << data_x << ", " << data_y << ", " << data_z << endl;
 
     if(openFile == fileNum)
     {
@@ -525,6 +531,10 @@ int OutCoreInterp::finish(const std::string& outputName, int outputFormat, unsig
     return 0;
 }
 
+void OutCoreInterp::isUserDefinedGrid(bool defined) {
+    user_defined_grid = defined;
+}
+
 void OutCoreInterp::updateInterpArray(int fileNum, double data_x, double data_y, double data_z)
 {
     double x;
@@ -538,7 +548,6 @@ void OutCoreInterp::updateInterpArray(int fileNum, double data_x, double data_y,
 
     x = data_x - lower_grid_x * GRID_DIST_X;
     y = data_y - lower_grid_y * GRID_DIST_Y;
-
 
     //if(lower_grid_y == 30 && data_y > GRID_DIST_Y * lower_grid_y)
     //printf("(%f %f) = (%d, %d)\n", data_x, data_y, lower_grid_x, lower_grid_y);
@@ -683,13 +692,13 @@ void OutCoreInterp::updateGridPoint(int fileNum, int x, int y, double data_z, do
     unsigned int coord = y * local_grid_size_x + x;
     GridFile *gf = gridMap[fileNum]->getGridFile();
 
-    if(gf == NULL || gf->interp == NULL)
+    if(gf == NULL || gf->interp == NULL || x >= local_grid_size_x)
     {
         //cout << "OutCoreInterp::updateGridPoint() gridFile is NULL" << endl;
         return;
     }
 
-    if(coord < gf->getMemSize() && coord != 0)
+    if(coord < gf->getMemSize() && coord >= 0)
     {
         if(gf->interp[coord].Zmin > data_z)
             gf->interp[coord].Zmin = data_z;
@@ -706,7 +715,7 @@ void OutCoreInterp::updateGridPoint(int fileNum, int x, int y, double data_z, do
 	gf->interp[coord].Zstd += delta * (data_z - gf->interp[coord].Zstd_tmp);
 	*/
 
-	double dist = pow(distance, Interpolation::WEIGHTER);
+    double dist = pow(distance, Interpolation::WEIGHTER);
         if (gf->interp[coord].sum != -1) {
             if (dist != 0) {
                 gf->interp[coord].Zidw += data_z/dist;
@@ -1185,7 +1194,7 @@ int OutCoreInterp::findFileNum(double data_y)
         }
     }
 
-    cerr << "findFileNum() error" << endl;
+    if (!user_defined_grid) cerr << "findFileNum() error" << endl;
 
     return -1;
 }

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -807,8 +807,8 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
             {
                 fprintf(arcFiles[i], "ncols %d\n", GRID_SIZE_X);
                 fprintf(arcFiles[i], "nrows %d\n", GRID_SIZE_Y);
-                fprintf(arcFiles[i], "xllcorner %f\n", min_x);
-                fprintf(arcFiles[i], "yllcorner %f\n", min_y);
+                fprintf(arcFiles[i], "xllcorner %f\n", min_x - 0.5*GRID_DIST_X);
+                fprintf(arcFiles[i], "yllcorner %f\n", min_y - 0.5*GRID_DIST_Y);
                 fprintf(arcFiles[i], "cellsize %f\n", GRID_DIST_X);
                 fprintf(arcFiles[i], "NODATA_value -9999\n");
             }
@@ -822,10 +822,10 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
         {
             if(gridFiles[i] != NULL)
             {
-                fprintf(gridFiles[i], "north: %f\n", max_y);
-                fprintf(gridFiles[i], "south: %f\n", min_y);
-                fprintf(gridFiles[i], "east: %f\n", max_x);
-                fprintf(gridFiles[i], "west: %f\n", min_x);
+                fprintf(gridFiles[i], "north: %f\n", min_y - 0.5*GRID_DIST_Y + GRID_DIST_Y*GRID_SIZE_Y);
+                fprintf(gridFiles[i], "south: %f\n", min_y - 0.5*GRID_DIST_Y);
+                fprintf(gridFiles[i], "east: %f\n", min_x - 0.5*GRID_DIST_X + GRID_DIST_X*GRID_SIZE_X);
+                fprintf(gridFiles[i], "west: %f\n", min_x - 0.5*GRID_DIST_X);
                 fprintf(gridFiles[i], "rows: %d\n", GRID_SIZE_Y);
                 fprintf(gridFiles[i], "cols: %d\n", GRID_SIZE_X);
             }

--- a/test/interpolation_test.cpp
+++ b/test/interpolation_test.cpp
@@ -6,7 +6,9 @@
 
 #include "config.hpp"
 
+#ifdef HAVE_GDAL
 #include "gdal_priv.h"
+#endif // HAVE_GDAL
 
 
 namespace points2grid

--- a/test/interpolation_test.cpp
+++ b/test/interpolation_test.cpp
@@ -324,4 +324,24 @@ TEST_F(InterpolationTest, ValuesUserGridLarge)
 }
 
 
+TEST_F(InterpolationTest, ValuesUserGridSmall)
+{
+    Interpolation interp(1, 1, 0.01, 0, INTERP_INCORE);
+    interp.init(infile, 1.5, 0.5, 1.5, 0.5);
+    interp.interpolation(infile, outfile, INPUT_ASCII, OUTPUT_FORMAT_ALL, OUTPUT_TYPE_ALL);
+
+    // Test ArcGIS data
+    std::ifstream asc;
+    asc.open((outfile + ".mean.asc").c_str());
+    AsciiData ascdata = read_asc_data(asc);
+    EXPECT_DOUBLE_EQ(ascdata.values[0], 3.0);
+
+    // Test GRID data
+    std::ifstream grid;
+    grid.open((outfile + ".mean.grid").c_str());
+    AsciiData griddata = read_grid_data(grid);
+    EXPECT_DOUBLE_EQ(griddata.values[0], 3.0);
+}
+
+
 }

--- a/test/interpolation_test.cpp
+++ b/test/interpolation_test.cpp
@@ -10,6 +10,73 @@ namespace points2grid
 {
 
 
+namespace
+{
+
+
+struct AscHeader
+{
+    int ncols;
+    int nrows;
+    double xllcorner;
+    double yllcorner;
+    double cellsize;
+    int NODATA_value;
+};
+
+struct GridHeader
+{
+    double north;
+    double south;
+    double east;
+    double west;
+    int rows;
+    int cols;
+};
+
+
+AscHeader read_asc_header(std::istream& is)
+{
+    AscHeader header;
+    std::streamsize n = std::numeric_limits<std::streamsize>::max();
+    is.ignore(n, ' ');
+    is >> header.ncols;
+    is.ignore(n, ' ');
+    is >> header.nrows;
+    is.ignore(n, ' ');
+    is >> header.xllcorner;
+    is.ignore(n, ' ');
+    is >> header.yllcorner;
+    is.ignore(n, ' ');
+    is >> header.cellsize;
+    is.ignore(n, ' ');
+    is >> header.NODATA_value;
+    return header;
+}
+
+GridHeader read_grid_header(std::istream& is)
+{
+    GridHeader header;
+    std::streamsize n = std::numeric_limits<std::streamsize>::max();
+    is.ignore(n, ' ');
+    is >> header.north;
+    is.ignore(n, ' ');
+    is >> header.south;
+    is.ignore(n, ' ');
+    is >> header.east;
+    is.ignore(n, ' ');
+    is >> header.west;
+    is.ignore(n, ' ');
+    is >> header.rows;
+    is.ignore(n, ' ');
+    is >> header.cols;
+    return header;
+}
+
+
+}
+
+
 class InterpolationTest : public ::testing::Test
 {
 public:
@@ -28,6 +95,18 @@ public:
         std::remove((outfile + ".mean.asc").c_str());
         std::remove((outfile + ".min.asc").c_str());
         std::remove((outfile + ".std.asc").c_str());
+        std::remove((outfile + ".den.grid").c_str());
+        std::remove((outfile + ".idw.grid").c_str());
+        std::remove((outfile + ".max.grid").c_str());
+        std::remove((outfile + ".mean.grid").c_str());
+        std::remove((outfile + ".min.grid").c_str());
+        std::remove((outfile + ".std.grid").c_str());
+        std::remove((outfile + ".den.tif").c_str());
+        std::remove((outfile + ".idw.tif").c_str());
+        std::remove((outfile + ".max.tif").c_str());
+        std::remove((outfile + ".mean.tif").c_str());
+        std::remove((outfile + ".min.tif").c_str());
+        std::remove((outfile + ".std.tif").c_str());
     }
 
     std::string infile;
@@ -59,6 +138,34 @@ TEST_F(InterpolationTest, Interpolate)
     EXPECT_EQ(4, interp.getDataCount());
     EXPECT_EQ(2, interp.getGridSizeX());
     EXPECT_EQ(2, interp.getGridSizeY());
+}
+
+
+TEST_F(InterpolationTest, Headers)
+{
+    Interpolation interp(1, 1, 1, 3, INTERP_INCORE);
+    interp.init(infile, INPUT_ASCII);
+    interp.interpolation(infile, outfile, INPUT_ASCII, OUTPUT_FORMAT_ALL, OUTPUT_TYPE_ALL);
+
+    std::ifstream asc;
+    asc.open((outfile + ".idw.asc").c_str());
+    AscHeader asc_header = read_asc_header(asc);
+    EXPECT_EQ(asc_header.ncols, 2);
+    EXPECT_EQ(asc_header.nrows, 2);
+    EXPECT_DOUBLE_EQ(asc_header.xllcorner, 0.5);
+    EXPECT_DOUBLE_EQ(asc_header.yllcorner, 0.5);
+    EXPECT_DOUBLE_EQ(asc_header.cellsize, 1.0);
+    EXPECT_EQ(asc_header.NODATA_value, -9999);
+
+    std::ifstream grid;
+    grid.open((outfile + ".idw.grid").c_str());
+    GridHeader grid_header = read_grid_header(grid);
+    EXPECT_DOUBLE_EQ(grid_header.north, 2.5);
+    EXPECT_DOUBLE_EQ(grid_header.south, 0.5);
+    EXPECT_DOUBLE_EQ(grid_header.east, 2.5);
+    EXPECT_DOUBLE_EQ(grid_header.west, 0.5);
+    EXPECT_EQ(grid_header.rows, 2);
+    EXPECT_EQ(grid_header.cols, 2);
 }
 
 


### PR DESCRIPTION
Setting a custom transformation and projection in the .tif format is already supported, but never used. I've set the output to include the correct transformation if a custom one is not supplied. Also adds unit test for .tif format.

Lots of great info from the [GDAL API Tutorial](http://www.gdal.org/gdal_tutorial.html) used here.

Fixes #18