### PR TITLE
User defined grid

### DIFF
--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -64,10 +64,11 @@ class P2G_DLL Interpolation
 {
 public:
     Interpolation(double x_dist, double y_dist, double radius,
-                  int _window_size, int _interpolation_mode);
+		  int _window_size, int _interpolation_mode);
     ~Interpolation();
 
     int init(const std::string& inputName, int inputFormat);
+    int init(const std::string& inputName, double n, double s, double e, double w);
     int interpolation(const std::string& inputName, const std::string& outputName, int inputFormat,
                       int outputFormat, unsigned int type);
     unsigned int getDataCount();

--- a/include/points2grid/OutCoreInterp.hpp
+++ b/include/points2grid/OutCoreInterp.hpp
@@ -78,6 +78,7 @@ public:
     virtual int update(double data_x, double data_y, double data_z);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    void isUserDefinedGrid(bool defined);
 
 private:
     void updateInterpArray(int fileNum, double data_x, double data_y, double data_z);
@@ -106,6 +107,8 @@ private:
     list<UpdateInfo> *qlist;
     GridMap **gridMap;
     int openFile;
+
+    bool user_defined_grid;
 };
 
 class UpdateInfo

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -413,6 +413,9 @@ void InCoreInterp::update_fourth_quadrant(double data_z, int base_x, int base_y,
 
 void InCoreInterp::updateGridPoint(int x, int y, double data_z, double distance)
 {
+    // Add checks for invalid indices that result from user-defined grids
+    if (x >= GRID_SIZE_X || x < 0 || y >= GRID_SIZE_Y || y < 0) return;
+
     if(interp[x][y].Zmin > data_z)
         interp[x][y].Zmin = data_z;
     if(interp[x][y].Zmax < data_z)

--- a/test/interpolation_geotiff_test.cpp
+++ b/test/interpolation_geotiff_test.cpp
@@ -46,4 +46,26 @@ TEST_F(InterpolationGeotiffTest, GeotiffHeaders)
 }
 
 
+TEST_F(InterpolationGeotiffTest, GeotiffHeadersUserGrid)
+{
+    Interpolation interp(1, 1, 0.01, 3, INTERP_INCORE);
+    interp.init(infile, 3.5, -0.5, 4.5, -1.5);
+    interp.interpolation(infile, outfile, INPUT_ASCII, OUTPUT_FORMAT_ALL, OUTPUT_TYPE_ALL);
+
+    GDALDataset *dataset;
+    GDALAllRegister();
+    dataset = (GDALDataset *) GDALOpen((outfile + ".mean.tif").c_str(), GA_ReadOnly);
+    ASSERT_TRUE(dataset != NULL);
+    double adfGeoTransform[6];
+    EXPECT_EQ(dataset->GetGeoTransform(adfGeoTransform), CE_None);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[0], -1.5);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[1], 1.0);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[2], 0.0);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[3], 3.5);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[4], 0.0);
+    EXPECT_DOUBLE_EQ(adfGeoTransform[5], -1.0);
+    delete dataset;
+}
+
+
 }


### PR DESCRIPTION
Adds option that allows users to specify the bounds of the resulting grid. Will be useful when comparing DEMs generated from point clouds that are from the same geographic location.

Bounds are defined at command line (using -n, -s, -e, -w flags) and represent the edges of the grid in the same way that bounds are represented in the .grid format.