### PR TITLE
fixes distance calculation for quadrant 1

### DIFF
--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -586,7 +586,7 @@ void OutCoreInterp::update_first_quadrant(int fileNum, double data_z, int base_x
             if(distance <= radius_sqr)
             {
                 // update GridPoint
-                updateGridPoint(fileNum, i, j, data_z, distance);
+                updateGridPoint(fileNum, i, j, data_z, sqrt(distance));
 
             } else if(j == base_y) {
                 //printf("return ");


### PR DESCRIPTION
The distance calculation between a point  and points in it's first quadrant around it was not taking the sqrt() whereas the other 3 quadrants were.

This would have created a bias when using idw and points in Q1 would have been weighted less than they should have.