### PR TITLE
Remove explicit forcing of 64bit on non-darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,10 +114,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     -D_GNU_SOURCE
     -D_LARGEFILE_SOURCE
     ${LFS_CFLAGS})
-
-  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    add_definitions(-m64)
-  endif()
 endif()
 
 if(WIN32)


### PR DESCRIPTION
I don't know why it was there, and it breaks the build (for me) on Ubuntu precise32. @hobu is there some reason why this can't go away?