### PR TITLE
Add regression test for #7, two point grid

### DIFF
--- a/include/points2grid/InCoreInterp.hpp
+++ b/include/points2grid/InCoreInterp.hpp
@@ -70,6 +70,7 @@ public:
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
     void calculate_grid_values();
+    const GridPoint& get_grid_point(int i, int j);
 
 private:
     GridPoint **interp;

--- a/include/points2grid/InCoreInterp.hpp
+++ b/include/points2grid/InCoreInterp.hpp
@@ -69,6 +69,7 @@ public:
     virtual int update(double data_x, double data_y, double data_z);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType);
     virtual int finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt);
+    void calculate_grid_values();
 
 private:
     GridPoint **interp;

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -180,13 +180,33 @@ int InCoreInterp::finish(const std::string& outputName, int outputFormat, unsign
 int InCoreInterp::finish(const std::string& outputName, int outputFormat, unsigned int outputType, double *adfGeoTransform, const char* wkt)
 {
     int rc;
-    int i,j;
 
     //struct tms tbuf;
     clock_t t0, t1;
 
-    for(i = 0; i < GRID_SIZE_X; i++)
-        for(j = 0; j < GRID_SIZE_Y; j++)
+    calculate_grid_values();
+
+    t0 = clock();
+
+    if((rc = outputFile(outputName, outputFormat, outputType, adfGeoTransform, wkt)) < 0)
+    {
+        cerr << "InCoreInterp::finish outputFile error" << endl;
+        return -1;
+    }
+
+    t1 = clock();
+
+    cerr << "Output Execution time: " << (double)(t1 - t0)/ CLOCKS_PER_SEC << std::endl;
+
+
+    return 0;
+}
+
+
+void InCoreInterp::calculate_grid_values()
+{
+    for(int i = 0; i < GRID_SIZE_X; i++)
+        for(int j = 0; j < GRID_SIZE_Y; j++)
         {
             if(interp[i][j].Zmin == DBL_MAX) {
                 //		interp[i][j].Zmin = NAN;
@@ -265,22 +285,8 @@ int InCoreInterp::finish(const std::string& outputName, int outputFormat, unsign
                 }
             }
     }
-
-    t0 = clock();
-
-    if((rc = outputFile(outputName, outputFormat, outputType, adfGeoTransform, wkt)) < 0)
-    {
-        cerr << "InCoreInterp::finish outputFile error" << endl;
-        return -1;
-    }
-
-    t1 = clock();
-
-    cerr << "Output Execution time: " << (double)(t1 - t0)/ CLOCKS_PER_SEC << std::endl;
-
-
-    return 0;
 }
+
 
 //////////////////////////////////////////////////////
 // Private Methods

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -288,6 +288,12 @@ void InCoreInterp::calculate_grid_values()
 }
 
 
+const GridPoint& InCoreInterp::get_grid_point(int i, int j)
+{
+    return interp[i][j];
+}
+
+
 //////////////////////////////////////////////////////
 // Private Methods
 //////////////////////////////////////////////////////

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
 
 set(src
     interpolation_test.cpp
+    issues/7_two_point_cloud.cpp
     )
 
 if (WITH_GDAL)

--- a/test/issues/7_two_point_cloud.cpp
+++ b/test/issues/7_two_point_cloud.cpp
@@ -1,0 +1,67 @@
+/*
+*
+COPYRIGHT AND LICENSE
+
+Copyright (c) 2015 Peter J. Gadomski <pete.gadomski@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. All advertising materials mentioning features or use of this
+software must display the following acknowledgement: This product
+includes software developed by the San Diego Supercomputer Center.
+
+4. Neither the names of the Centers nor the names of the contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*
+*/
+
+#include <gtest/gtest.h>
+
+#include <points2grid/InCoreInterp.hpp>
+
+
+namespace points2grid
+{
+
+
+TEST(Issue7, TwoPointCloud)
+{
+    InCoreInterp interp(1e4, 1e4, 1, 1, 1e4, 0, 10, 0, 10, 3);
+    interp.init();
+    interp.update(0, 0, 10);
+    interp.update(10, 10, 0);
+    interp.calculate_grid_values();
+    GridPoint point = interp.get_grid_point(0, 0);
+    EXPECT_EQ(2, point.count);
+    EXPECT_EQ(5, point.Zmean);
+    EXPECT_EQ(0, point.Zmin);
+    EXPECT_EQ(10, point.Zmax);
+}
+
+
+}


### PR DESCRIPTION
Add a regression test for #7, including some extra bits to `InCoreInterp` that allow for easier testing. Basically, granulize some of the grid calculations so the values can be inspected before any file writes.

Opening a PR just to confirm things build out correctly on Travis.