### PR TITLE
Added functionality to filter out LAS points based on classification.

### DIFF
--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     double GRID_DIST_Y = 6.0;
     double searchRadius = (double) sqrt(2.0) * GRID_DIST_X;
     int window_size = 0;
-    int las_exclude_class = -1;
+    std::vector<int> las_exclude_classifications;
 
     bool user_defined_bounds = false;
     double n = 0.0, s = 0.0, e = 0.0, w = 0.0;
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
     ("fill_window_size", po::value<int>(), "The fill window is set to value. Permissible values are 3, 5 and 7.");
     
     lasf.add_options()
-    ("exclude_point", po::value<int>(), "Exclude points with the specified classification");
+    ("exclude_points", po::value<std::vector<int> >()->multitoken(), "Exclude points with the specified classification. Can specify multiple classifications seperated by a space.");
 
     desc.add(general).add(df).add(ot).add(res).add(bnds).add(nf).add(lasf);
 
@@ -283,6 +283,10 @@ int main(int argc, char **argv)
             }
         }
 
+        if(vm.count("exclude_points")) {
+            las_exclude_classifications = vm["exclude_points"].as<std::vector<int> >();
+        }
+
 #ifdef CURL_FOUND
         if(vm.count("data_file_name")) {
             strncpy(inputName, vm["data_file_name"].as<std::string>().c_str(), sizeof(inputName));
@@ -291,8 +295,7 @@ int main(int argc, char **argv)
             strncpy(inputURL, vm["data_file_url"].as<std::string>().c_str(), sizeof(inputURL));
         }
 
-        if((inputName == NULL || !strcmp(inputName, "")) &&
-                (inputURL == NULL || !strcmp(inputURL, "")))
+        if((inputName == NULL || !strcmp(inputName, "")) && (inputURL == NULL || !strcmp(inputURL, "")))
         {
             throw std::logic_error("you must specify a valid data file");
         }
@@ -333,11 +336,6 @@ int main(int argc, char **argv)
             else {
                 throw std::logic_error("'" + im + "' is not a recognized interpolation_mode");
             }
-        }
-        
-                
-        if(vm.count("exclude_point")) {
-            las_exclude_class = vm["exclude_point"].as<int>();
         }
 
         if(type == 0)
@@ -419,7 +417,7 @@ int main(int argc, char **argv)
     }
     
     // Exclude points
-    ip->setLasExcludeClassification(las_exclude_class);
+    ip->setLasExcludeClassification(las_exclude_classifications);
     
 
     t1 = clock();

--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
     ("fill_window_size", po::value<int>(), "The fill window is set to value. Permissible values are 3, 5 and 7.");
     
     lasf.add_options()
-    ("exclude_points", po::value<std::vector<int> >()->multitoken(), "Exclude points with the specified classification. Can specify multiple classifications seperated by a space.");
+    ("exclude_class", po::value<std::vector<int> >()->multitoken(), "Exclude points with the specified classification. Can specify multiple classifications seperated by a space.");
 
     desc.add(general).add(df).add(ot).add(res).add(bnds).add(nf).add(lasf);
 
@@ -283,8 +283,8 @@ int main(int argc, char **argv)
             }
         }
 
-        if(vm.count("exclude_points")) {
-            las_exclude_classifications = vm["exclude_points"].as<std::vector<int> >();
+        if(vm.count("exclude_class")) {
+            las_exclude_classifications = vm["exclude_class"].as<std::vector<int> >();
         }
 
 #ifdef CURL_FOUND

--- a/apps/points2grid.cpp
+++ b/apps/points2grid.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
        desc;
 
     general.add_options()
-    ("help", "produce a help message")
+    ("help,h", "produce a help message")
     ("output_file_name,o", po::value<std::string>(), "required. name of output file without extension, i.e. if you want the output file to be test.asc, this parameter shoud be \"test\"")
     ("search_radius,r", po::value<float>(), "specifies the search radius. The default value is square root 2 of horizontal distance in a grid cell")
     ("output_format", po::value<std::string>(), "'all' generates every possible format,\n"

--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -79,6 +79,8 @@ public:
     // for debug
     void printArray();
 
+	void setLasExcludeClassification(int classification);
+
     // depricated
     void setRadius(double r);
 
@@ -106,6 +108,8 @@ private:
     double radius_sqr;
     int window_size;
     int interpolation_mode;
+    
+    int las_exclude_classification;
 
     CoreInterp *interp;
 };

--- a/include/points2grid/Interpolation.hpp
+++ b/include/points2grid/Interpolation.hpp
@@ -79,7 +79,7 @@ public:
     // for debug
     void printArray();
 
-	void setLasExcludeClassification(int classification);
+	void setLasExcludeClassification(std::vector<int> classification);
 
     // depricated
     void setRadius(double r);
@@ -108,8 +108,10 @@ private:
     double radius_sqr;
     int window_size;
     int interpolation_mode;
-    
-    int las_exclude_classification;
+
+    bool exclude_point_class(int classification);
+
+    std::vector<int> las_exclude_classification;
 
     CoreInterp *interp;
 };

--- a/include/points2grid/lasfile.hpp
+++ b/include/points2grid/lasfile.hpp
@@ -174,6 +174,18 @@ public:
         return z;
     }
     
+    inline int getClassification(size_t point)
+    {
+		int classification_offset = 15;
+        char *position = (char *)points_offset() + stride() * point + classification_offset;
+        
+        int *classi = (int *)position;
+        
+        int classification = *classi & 0x1F;
+        
+        return classification;
+    }
+    
 private:
     void updateMinsMaxes() {
         if (start_offset_ == 0 && count_ == -1)

--- a/src/InCoreInterp.cpp
+++ b/src/InCoreInterp.cpp
@@ -801,7 +801,7 @@ int InCoreInterp::outputFile(const std::string& outputName, int outputFormat, un
             if (gdalFiles[i] != NULL)
             {
                 float *poRasterData = new float[GRID_SIZE_X*GRID_SIZE_Y];
-                for (int j = 0; j < GRID_SIZE_X*GRID_SIZE_Y; j++)
+                for (j = 0; j < GRID_SIZE_X*GRID_SIZE_Y; j++)
                 {
                     poRasterData[j] = 0;
                 }

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -72,7 +72,6 @@ POSSIBILITY OF SUCH DAMAGE.
 Interpolation::Interpolation(double x_dist, double y_dist, double radius,
                              int _window_size, int _interpolation_mode = INTERP_AUTO) : GRID_DIST_X (x_dist), GRID_DIST_Y(y_dist), interp(NULL)
 {
-	las_exclude_classification = -1;
     data_count = 0;
     radius_sqr = radius * radius;
     window_size = _window_size;
@@ -406,8 +405,9 @@ int Interpolation::interpolation(const std::string& inputName,
             
             data_x -= min_x;
             data_y -= min_y;
-            
-            if (las_exclude_classification != data_class) {
+
+            // If exclude point is true then point should be skipped
+            if (!exclude_point_class(data_class)) {
 				if ((rc = interp->update(data_x, data_y, data_z)) < 0) {
 					cerr << "interp->update() error while processing " << endl;
 					return -1;
@@ -435,9 +435,23 @@ void Interpolation::setRadius(double r)
     radius_sqr = r * r;
 }
 
-void Interpolation::setLasExcludeClassification(int classification)
+void Interpolation::setLasExcludeClassification(std::vector<int> classification)
 {
 	las_exclude_classification = classification;
+}
+
+bool Interpolation::exclude_point_class(int classification)
+{
+    // This checks if the classification vector contains the current classification, if it does return true
+    // to exclude point. Otherwise return false to include point
+    if(std::find(las_exclude_classification.begin(), las_exclude_classification.end(), classification) != las_exclude_classification.end())
+    {
+        // Classification is in vector, exclude point
+        return true;
+    } else {
+        // Classification isn't in vector, include point
+        return false;
+    }
 }
 
 unsigned int Interpolation::getDataCount()

--- a/src/Interpolation.cpp
+++ b/src/Interpolation.cpp
@@ -72,6 +72,7 @@ POSSIBILITY OF SUCH DAMAGE.
 Interpolation::Interpolation(double x_dist, double y_dist, double radius,
                              int _window_size, int _interpolation_mode = INTERP_AUTO) : GRID_DIST_X (x_dist), GRID_DIST_Y(y_dist), interp(NULL)
 {
+	las_exclude_classification = -1;
     data_count = 0;
     radius_sqr = radius * radius;
     window_size = _window_size;
@@ -336,6 +337,7 @@ int Interpolation::interpolation(const std::string& inputName,
     //unsigned int i;
     double data_x, data_y;
     double data_z;
+    int data_class;
 
     //struct tms tbuf;
     //clock_t t0, t1;
@@ -400,14 +402,17 @@ int Interpolation::interpolation(const std::string& inputName,
             data_x = las.getX(index);
             data_y = las.getY(index);
             data_z = las.getZ(index);
+            data_class = las.getClassification(index);
             
             data_x -= min_x;
             data_y -= min_y;
             
-            if ((rc = interp->update(data_x, data_y, data_z)) < 0) {
-                cerr << "interp->update() error while processing " << endl;
-                return -1;
-            }
+            if (las_exclude_classification != data_class) {
+				if ((rc = interp->update(data_x, data_y, data_z)) < 0) {
+					cerr << "interp->update() error while processing " << endl;
+					return -1;
+				}
+			}
             index++;
         }
         
@@ -428,6 +433,11 @@ int Interpolation::interpolation(const std::string& inputName,
 void Interpolation::setRadius(double r)
 {
     radius_sqr = r * r;
+}
+
+void Interpolation::setLasExcludeClassification(int classification)
+{
+	las_exclude_classification = classification;
 }
 
 unsigned int Interpolation::getDataCount()

--- a/src/OutCoreInterp.cpp
+++ b/src/OutCoreInterp.cpp
@@ -1090,7 +1090,7 @@ int OutCoreInterp::outputFile(const std::string& outputName, int outputFormat, u
                     cerr << "        " << i << ": from " << (start/GRID_SIZE_X) << " to " << (end/GRID_SIZE_X) << endl;
 
                     float *poRasterData = new float[GRID_SIZE_X*GRID_SIZE_Y];
-                    for (int j = 0; j < GRID_SIZE_X*GRID_SIZE_Y; j++)
+                    for (j = 0; j < GRID_SIZE_X*GRID_SIZE_Y; j++)
                     {
                         poRasterData[j] = 0;
                     }
@@ -1299,10 +1299,10 @@ void OutCoreInterp::finalize()
 }
 
 void OutCoreInterp::get_temp_file_name(char *fname, size_t fname_len) {
-    const char *pfx = "grd";
-    char *tname = NULL;
+    int tname = -1;
     char tname_template[] = "/tmp/p2gXXXXXX";
 #ifdef _WIN32
+	const char *pfx = "grd";
     char dir[MAX_PATH];
     DWORD gtpRetVal;
 
@@ -1326,16 +1326,15 @@ void OutCoreInterp::get_temp_file_name(char *fname, size_t fname_len) {
     }
 #else
 
-    tname = mktemp(tname_template);
-    // tname = tempnam(NULL, pfx);
-    if (tname == NULL) {
+    tname = mkstemp(tname_template);
+    if (tname == -1) {
         throw std::logic_error("Could not create temporary file.");
     }
 #endif
 
-    size_t tname_len = strlen(tname);
+    size_t tname_len = sizeof(tname_template);
     if (tname_len < fname_len) {
-        strncpy(fname, tname, tname_len);
+        strncpy(fname, tname_template, tname_len);
         fname[tname_len] = '\0';
     }
     else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
 
 set(src
     interpolation_test.cpp
+    exclude_class_test.cpp
     issues/7_two_point_cloud.cpp
     )
 

--- a/test/exclude_class_test.cpp
+++ b/test/exclude_class_test.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <points2grid/Interpolation.hpp>
+
+#include <points2grid/config.h>
+#include <points2grid/Global.hpp>
+#include <cmath>
+
+#include "fixtures.hpp"
+
+
+namespace points2grid {
+
+
+namespace {
+
+    class ExcludeClassTest : public ExcludePointsTest {
+    };
+
+}
+
+struct AscHeader {
+    int ncols;
+    int nrows;
+    double xllcorner;
+    double yllcorner;
+    double cellsize;
+    int NODATA_value;
+};
+
+struct AsciiData {
+    AsciiData(int numvals) : values(0) {
+        if (numvals > 0) values = new double[numvals];
+    }
+
+    ~AsciiData() {
+        if (values) delete[] values;
+    }
+
+    double *values;
+};
+
+AscHeader read_asc_header(std::istream &is) {
+    AscHeader header;
+    std::streamsize n = std::numeric_limits<std::streamsize>::max();
+    is.ignore(n, ' ');
+    is >> header.ncols;
+    is.ignore(n, ' ');
+    is >> header.nrows;
+    is.ignore(n, ' ');
+    is >> header.xllcorner;
+    is.ignore(n, ' ');
+    is >> header.yllcorner;
+    is.ignore(n, ' ');
+    is >> header.cellsize;
+    is.ignore(n, ' ');
+    is >> header.NODATA_value;
+    return header;
+}
+
+AsciiData read_asc_data(std::istream &is) {
+    AscHeader hdr = read_asc_header(is);
+    AsciiData data(hdr.ncols * hdr.nrows);
+
+    for (int i = 0; i < hdr.ncols * hdr.nrows; ++i)
+        is >> data.values[i];
+
+    return data;
+}
+
+TEST_F(ExcludeClassTest, InitLAS) {
+    Interpolation interp(1, 1, 1, 3, INTERP_INCORE);
+    int retval = interp.init(infile, INPUT_LAS);
+    EXPECT_EQ(0, retval);
+}
+
+
+TEST_F(ExcludeClassTest, Interpolate) {
+    std::vector<int> exclude_class;
+    exclude_class.push_back(1);
+
+    Interpolation interp(1, 1, 1, 3, INTERP_INCORE);
+    interp.init(infile, INPUT_LAS);
+    interp.setLasExcludeClassification(exclude_class);
+
+    int retval = interp.interpolation(infile, outfile, INPUT_LAS, OUTPUT_FORMAT_ARC_ASCII, OUTPUT_TYPE_ALL);
+    EXPECT_EQ(0, retval);
+
+    // Get a count of valid data
+    std::ifstream asc;
+    asc.open((outfile + ".idw.asc").c_str());
+    AscHeader asc_header = read_asc_header(asc);
+    AsciiData ascdata = read_asc_data(asc);
+
+    int valid_data = 0;
+
+    for (int i = 0; i < asc_header.ncols * asc_header.nrows; ++i) {
+        if (ascdata.values[i] != asc_header.NODATA_value) {
+            ++valid_data;
+        }
+    }
+
+    EXPECT_EQ(4056, valid_data);
+}
+
+}

--- a/test/fixtures.hpp
+++ b/test/fixtures.hpp
@@ -46,5 +46,42 @@ public:
 
 };
 
+class ExcludePointsTest : public ::testing::Test
+{
+public:
+
+    virtual void SetUp()
+    {
+        infile = get_test_data_filename("example.las");
+        outfile = get_test_data_filename("outfile");
+    }
+
+    virtual void TearDown()
+    {
+        std::remove((outfile + ".den.asc").c_str());
+        std::remove((outfile + ".idw.asc").c_str());
+        std::remove((outfile + ".max.asc").c_str());
+        std::remove((outfile + ".mean.asc").c_str());
+        std::remove((outfile + ".min.asc").c_str());
+        std::remove((outfile + ".std.asc").c_str());
+        std::remove((outfile + ".den.grid").c_str());
+        std::remove((outfile + ".idw.grid").c_str());
+        std::remove((outfile + ".max.grid").c_str());
+        std::remove((outfile + ".mean.grid").c_str());
+        std::remove((outfile + ".min.grid").c_str());
+        std::remove((outfile + ".std.grid").c_str());
+        std::remove((outfile + ".den.tif").c_str());
+        std::remove((outfile + ".idw.tif").c_str());
+        std::remove((outfile + ".max.tif").c_str());
+        std::remove((outfile + ".mean.tif").c_str());
+        std::remove((outfile + ".min.tif").c_str());
+        std::remove((outfile + ".std.tif").c_str());
+    }
+
+    std::string infile;
+    std::string outfile;
+
+};
+
 
 }


### PR DESCRIPTION
I added an argument `--exclude_points` which accepts multiple integers separated by spaces. This argument removes LAS points with the given classifications from the output. 

As points classified as 7 are normally noise this would allow people to exclude noise from the output, this can for example remove clouds if they have been classified.

Also fixed some compiler warnings. (Should of really put that in a separate request)